### PR TITLE
Fix Microsoft in footer

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -27,7 +27,7 @@ export default async function RootLayout({
               outerClassName="bg-zinc-800"
               innerClassName="text-zinc-100 text-right text-xs p-2"
             >
-              &copy;Micosoft 2023
+              &copy;Microsoft 2023
             </Block>
           </main>
           <Chat />


### PR DESCRIPTION
## Purpose
Microsoft is currently spelled wrong in the footer.

## Does this introduce a breaking change?
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[x] Other... Please describe: Typo fix
```

## How to Test
Run the app, the footer should show "Microsoft" instead of "Micosoft".
